### PR TITLE
Use instance variable

### DIFF
--- a/contextmenu.js
+++ b/contextmenu.js
@@ -59,7 +59,7 @@ export default function ContextMenu(menu, options){
 		var container = document.getElementById('cm_' + num);
 		container.innerHTML = "";
 
-		container.appendChild(renderLevel(menu));
+		container.appendChild(renderLevel(this.menu));
 	}
 
 	function renderLevel(level){


### PR DESCRIPTION
Hello Dan,

Thanks for developing this context menu!
I made a very small change that allows us to reuse a single ContextMenu instance.
Now we can easily set a new menu structure on an existing ContextMenu instance:
```
$scope.contextMenu.menu = $scope.contextmenuItems;
$scope.contextMenu.reload();
$scope.contextMenu.display(showOptions);
```
One word, a complete other world for us ;-)

Thanks !!!
Bart Butenaers